### PR TITLE
Update transform.lua

### DIFF
--- a/modules/vendor/c2c/transform.lua
+++ b/modules/vendor/c2c/transform.lua
@@ -1,59 +1,66 @@
 -- This file enable device data transformation for the template user
+-- MODIFY IT TO SUITE YOUR NEEDS.
+-- 
+-- You MUST define here how to decode your device sensore Hex value into a standard type for application ingestion.
+-- All transformations MUST match channels defined in the module `vendor.configIO` 
 --
 -- This file is in the 'vendor' safeNamespace and changes will persists upon template updates
 local transform = {}
 
--- local parser_factory = require("bytes.parser_factory")
+local parser_factory = require("bytes.parser_factory")
 
--- --Gives parsed data for data_in, depending port used, type of parse will be different
--- local uplink_by_ports = {
---   --port number
---   ["1"] = function (hex) 
---     return to_json({
---       --Data attribute temperature must match with configIO
---       ["temperature"] = parser_factory.getfloat_32(parser_factory.fromhex(hex),0),
---       ["machine_status"] = parser_factory.getstring(parser_factory.fromhex(hex),4,5)
---     })
---   end
---   -- Other Cases for other ports must be implemented here
--- }
+-- Defines a decoding function
+local function decode_temp_status(hex)
+   -- Here one port data contains 2 channels values, so a map needs to be returned:
+   return to_json({
+      -- Data attribute temperature must match with configIO
+      ["temperature"] = parser_factory.getfloat_32(parser_factory.fromhex(hex),0),
+      ["machine_status"] = parser_factory.getstring(parser_factory.fromhex(hex),4,5)
+    })
+end
 
--- -- Depending name, encode data to be send in downlink, in hex value. 
--- -- On config IO, corresponding to channel(s) with control set to true in properties
--- local downlink_by_names = {
---   ["button_push"] = function (new_machine_status) 
---     return {
---       ["cnf"] = false,
---       ["data"] = parser_factory.sendbool(tostring(new_machine_status))
---       -- port is set directly in murano2cloud function, look carrefuly
---     }
---     end
---   -- Other Cases for other ports must be implemented
--- }
+local uplink_decoding = {
+  -- keys MUST match the channels name defined in the module `vendor.configIO` 
+  ["temperature"] = decode_temp_status,
+  ["machine_status"] = decode_temp_status
+  -- Other Cases for other ports must be implemented here
+}
 
+-- Here downling channels will be transformed to expected Hex value
+-- On config IO, corresponding to channel(s) MUST defines `properties.control` to `true`
+local downlink_encoding = {
+  ["button_push"] = function(new_machine_status) 
+    return {
+      ["cnf"] = false,
+      ["data"] = parser_factory.sendbool(tostring(new_machine_status))
+      -- port is set automatically from the configIO `protocol_config.app_specific_config.port` value
+    }
+    end
+  -- Other Cases for other ports must be implemented
+}
 
--- function transform.data_in(cloud_data)
---   -- Transform data from the 3rd party service to Murano
---   if uplink_by_ports[tostring(cloud_data.mod.port)] ~= nil then
---     return uplink_by_ports[tostring(cloud_data.mod.port)](cloud_data.mod.data)
---   else
---     return '{}'
---   end
--- end
+function transform.data_in(cloud_data)
+ -- Transform data from the 3rd party service to Murano
+ if uplink_decoding[tostring(cloud_data.mod.channel)] ~= nil then
+   return uplink_decoding[tostring(cloud_data.mod.channel)](cloud_data.mod.data)
+ else
+   return '{}'
+ end
+end
 
--- function transform.data_out(murano_data)
---   if murano_data ~= nil then
---     -- Transform data from Murano to the 3rd party service : hex message in Mqtt Client.
---     -- Downlink by names will create encoded data matching config with your data_out Key value.
---     for key, value in pairs(murano_data) do
---       if downlink_by_names[key] ~= nil then
---         return downlink_by_names[key](value)
---       else
---         return nil
---       end
---     end
---   end
---   return nil
--- end
+function transform.data_out(murano_data)
+  if murano_data ~= nil then
+    -- Transform data from Murano to the 3rd party service : hex message sent to the device.
+    -- ConfigIO `protocol_config.app_specific_config.port` channels values is used to match murano_data downlink keys into lorawan port
+    for key, value in pairs(murano_data) do
+      if downlink_by_names[key] ~= nil then
+        return downlink_by_names[key](value)
+      else
+        return nil
+      end
+    end
+  end
+  return nil
+end
 
 return transform


### PR DESCRIPTION
As configIO example is not commented, lets do the same here.
I see the encoding function is called `sendbool` why not `encodebool` or `boolToHex`?
I changed the `cloud_data.mod.port` to expect `cloud_data.mod.channel` which assumes the channel get resolved from the configIO upfront.